### PR TITLE
Remove extra dot

### DIFF
--- a/apps/bot_engine/lib/bot_engine/responder.ex
+++ b/apps/bot_engine/lib/bot_engine/responder.ex
@@ -102,7 +102,7 @@ defmodule BotEngine.Responder do
       end) |>
       Enum.join(" ")
 
-    resp <> ". We're very lucky to have them :)"
+    resp <> " We're very lucky to have them :)"
   end
 
   defp lookup_talk(query) do


### PR DESCRIPTION
Remove extra dot.

Before:

`Our <category> sponsors are <name> (<url>).. We're lucky to have them!`

Now:

`Our <category> sponsors are <name> (<url>). We're lucky to have them!`